### PR TITLE
feat: reintroduce custom systems

### DIFF
--- a/src/monitorUtil.ts
+++ b/src/monitorUtil.ts
@@ -46,7 +46,8 @@ const makeJsonResponse = (result: MonitorResult, systemResults: MonitoredSystem[
   message: result,
   subSystems: systemResults.map(system => {
     const { key, result, ignored, required } = system
-    return { key, result, ignored, required }
+    const name = system.name || system.key
+    return { key, name, result, ignored, required }
   }),
 })
 
@@ -55,7 +56,7 @@ const makePlainResponse = (result: MonitorResult, systemResults: MonitoredSystem
 
   const subSystems = systemResults.map(system => {
     const systemMessage = makePlainSystemMessage(system)
-    return `${system.key} - ${systemMessage}`
+    return `${system.name || system.key} - ${systemMessage}`
   })
 
   return [header, ...subSystems].join('\n')

--- a/src/subSystems.test.ts
+++ b/src/subSystems.test.ts
@@ -52,20 +52,31 @@ describe('check systems', () => {
     const successfulSystem: MonitoredSystem = {
       key: 'custom',
       name: 'customSystem',
-      isOk: true,
-      message: 'Some custom message',
+      customCheck: {
+        isOk: true,
+        message: 'Some custom message',
+      },
     }
     const unsuccessfulSystem: MonitoredSystem = {
       key: 'custom',
       name: 'unsuccessfulSystem',
-      isOk: false,
-      message: 'Some error from custom subSystem',
+      customCheck: {
+        isOk: false,
+        message: 'Some error from custom subSystem',
+      },
     }
     const invalidCustomSystem: MonitoredSystem = {
       key: 'custom',
       name: 'invalidCustomSystem',
-      // @ts-ignore
-      isOk: 200,
+      customCheck: {
+        // @ts-ignore
+        isOk: 200,
+      },
+    }
+
+    const customSystemMissingCustomCheck: MonitoredSystem = {
+      key: 'custom',
+      name: 'customSystemMissingCustomCheck',
     }
 
     it('creates a successful result when "isOk" is true', async () => {
@@ -84,12 +95,30 @@ describe('check systems', () => {
       expect(checkedSystems[0].result?.message).toEqual('Some error from custom subSystem')
     })
 
-    it('returns no "result" field when a custom system does not contain a boolean property "isOk"', async () => {
-      const checkedSystems = await checkSystems([invalidCustomSystem])
-
-      expect(checkedSystems[0].name).toEqual('invalidCustomSystem')
-      expect(checkedSystems[0].result).toEqual(undefined)
+    it('creates an unsuccessful result if property customCheck is missing', async () => {
+      const checkedSystems = await checkSystems([customSystemMissingCustomCheck])
+      expect(checkedSystems[0].name).toEqual('customSystemMissingCustomCheck')
+      expect(checkedSystems[0].result?.status).toEqual(false)
+      expect(checkedSystems[0].result?.message).toContain(
+        'invalid configuration: custom system missing required property "customCheck"'
+      )
     })
+
+    it('creates an unsuccessful result if property customCheck is missing', async () => {
+      const checkedSystems = await checkSystems([invalidCustomSystem])
+      expect(checkedSystems[0].name).toEqual('invalidCustomSystem')
+      expect(checkedSystems[0].result?.status).toEqual(false)
+      expect(checkedSystems[0].result?.message).toContain(
+        'invalid configuration: custom system missing required property "isOk"'
+      )
+    })
+
+    // it('returns no "result" field when a custom system does not contain a boolean property "isOk"', async () => {
+    //   const checkedSystems = await checkSystems([invalidCustomSystem])
+
+    //   expect(checkedSystems[0].name).toEqual('invalidCustomSystem')
+    //   expect(checkedSystems[0].result).toEqual(undefined)
+    // })
 
     it('logs a warning when a custom system does not contain a boolean property "isOk"', async () => {
       await checkSystems([invalidCustomSystem])

--- a/src/subSystems.test.ts
+++ b/src/subSystems.test.ts
@@ -113,13 +113,6 @@ describe('check systems', () => {
       )
     })
 
-    // it('returns no "result" field when a custom system does not contain a boolean property "isOk"', async () => {
-    //   const checkedSystems = await checkSystems([invalidCustomSystem])
-
-    //   expect(checkedSystems[0].name).toEqual('invalidCustomSystem')
-    //   expect(checkedSystems[0].result).toEqual(undefined)
-    // })
-
     it('logs a warning when a custom system does not contain a boolean property "isOk"', async () => {
       await checkSystems([invalidCustomSystem])
 

--- a/src/subSystems.test.ts
+++ b/src/subSystems.test.ts
@@ -11,6 +11,7 @@ describe('select systems to include', () => {
     { key: 'redis' },
     { key: 'sqldb' },
     { key: 'local' },
+    { key: 'custom' },
     { key: 'anyName' },
   ] as MonitoredSystem[]
   it('do not select any systems on when probe=liveness', async () => {
@@ -24,9 +25,10 @@ describe('select systems to include', () => {
         expect.objectContaining({ key: 'mongodb' }),
         expect.objectContaining({ key: 'redis' }),
         expect.objectContaining({ key: 'sqldb' }),
+        expect.objectContaining({ key: 'custom' }),
       ])
     )
-    expect(results.length).toBe(3)
+    expect(results.length).toBe(4)
   })
   it('select all systems when probe=full', async () => {
     const results = filterSystems('full', systemList)
@@ -37,6 +39,7 @@ describe('select systems to include', () => {
         expect.objectContaining({ key: 'redis' }),
         expect.objectContaining({ key: 'sqldb' }),
         expect.objectContaining({ key: 'local' }),
+        expect.objectContaining({ key: 'custom' }),
         expect.objectContaining({ key: 'anyName' }),
       ])
     )
@@ -45,6 +48,56 @@ describe('select systems to include', () => {
 })
 
 describe('check systems', () => {
+  describe('custom systems', () => {
+    const successfulSystem: MonitoredSystem = {
+      key: 'custom',
+      name: 'customSystem',
+      isOk: true,
+      message: 'Some custom message',
+    }
+    const unsuccessfulSystem: MonitoredSystem = {
+      key: 'custom',
+      name: 'unsuccessfulSystem',
+      isOk: false,
+      message: 'Some error from custom subSystem',
+    }
+    const invalidCustomSystem: MonitoredSystem = {
+      key: 'custom',
+      name: 'invalidCustomSystem',
+      // @ts-ignore
+      isOk: 200,
+    }
+
+    it('creates a successful result when "isOk" is true', async () => {
+      const checkedSystems = await checkSystems([successfulSystem])
+
+      expect(checkedSystems[0].name).toEqual('customSystem')
+      expect(checkedSystems[0].result?.status).toEqual(true)
+      expect(checkedSystems[0].result?.message).toEqual('Some custom message')
+    })
+
+    it('creates an unsuccessful result when "isOk" is false', async () => {
+      const checkedSystems = await checkSystems([unsuccessfulSystem])
+
+      expect(checkedSystems[0].name).toEqual('unsuccessfulSystem')
+      expect(checkedSystems[0].result?.status).toEqual(false)
+      expect(checkedSystems[0].result?.message).toEqual('Some error from custom subSystem')
+    })
+
+    it('returns no "result" field when a custom system does not contain a boolean property "isOk"', async () => {
+      const checkedSystems = await checkSystems([invalidCustomSystem])
+
+      expect(checkedSystems[0].name).toEqual('invalidCustomSystem')
+      expect(checkedSystems[0].result).toEqual(undefined)
+    })
+
+    it('logs a warning when a custom system does not contain a boolean property "isOk"', async () => {
+      await checkSystems([invalidCustomSystem])
+
+      expect(log.warn).toHaveBeenCalled()
+    })
+  })
+
   describe('unknown systems', () => {
     const unknownSystem = { key: 'unknownType', unknownField: {} } as unknown as MonitoredSystem
     it('returns no "result" field when a system is unknown', async () => {

--- a/src/subSystems.ts
+++ b/src/subSystems.ts
@@ -134,15 +134,23 @@ const checkSqldbSystem = async (system: MonitoredSystem): Promise<SystemCheckRes
 }
 
 const checkCustomSystem = (system: MonitoredSystem): SystemCheckResult | undefined => {
-  const { isOk, message } = system
-
-  if (isOk != undefined && typeof isOk == 'boolean') {
-    return {
-      status: isOk,
-      message,
+  try {
+    if (!system.customCheck) {
+      throw new Error('invalid configuration: custom system missing required property "customCheck"')
     }
+    const { isOk, message } = system.customCheck
+
+    if (isOk != undefined && typeof isOk == 'boolean') {
+      return {
+        status: isOk,
+        message,
+      }
+    }
+    throw new Error('invalid configuration: custom system missing required property "isOk"')
+  } catch (error) {
+    log.error('@kth/monitor - custom system check failed', error)
+    return { status: false, message: (error || '').toString() }
   }
-  log.error('@kth/monitor - custom system missing property "isOk"', system)
 }
 
 const sleep = async (delay: number) =>

--- a/src/subSystems.ts
+++ b/src/subSystems.ts
@@ -11,7 +11,7 @@ export const filterSystems = (probeType: ProbeType, systems: MonitoredSystem[] =
   }
 
   if (probeType === 'readyness') {
-    return systems.filter(system => ['redis', 'mongodb', 'sqldb'].includes(system.key))
+    return systems.filter(system => ['redis', 'mongodb', 'sqldb', 'custom'].includes(system.key))
   }
 
   return []
@@ -47,6 +47,8 @@ const checkSystem = async (system: MonitoredSystem): Promise<MonitoredSystem> =>
     result.result = await checkKthApiSystem(system)
   } else if (isSqldbSystem(system)) {
     result.result = await checkSqldbSystem(system)
+  } else if (isValidCustomSystem(system)) {
+    result.result = checkCustomSystem(system)
   } else {
     result.ignored = true
     log.warn('@kth/monitor - Unknown system', system)
@@ -58,6 +60,7 @@ const isMongodbSystem = (system: MonitoredSystem) => system.key === 'mongodb'
 const isRedisSystem = (system: MonitoredSystem) => system.key === 'redis'
 const isKthApiSystem = (system: MonitoredSystem) => system.endpoint != undefined
 const isSqldbSystem = (system: MonitoredSystem) => system.key === 'sqldb'
+const isValidCustomSystem = (system: MonitoredSystem) => system.key === 'custom'
 
 const checkMongodbSystem = async (system: MonitoredSystem): Promise<SystemCheckResult> => {
   if (typeof system.db?.isOk != 'function') {
@@ -128,6 +131,18 @@ const checkSqldbSystem = async (system: MonitoredSystem): Promise<SystemCheckRes
     log.error('@kth/monitor - Sqldb check failed', error)
     return { status: false, message: (error || '').toString() }
   }
+}
+
+const checkCustomSystem = (system: MonitoredSystem): SystemCheckResult | undefined => {
+  const { isOk, message } = system
+
+  if (isOk != undefined && typeof isOk == 'boolean') {
+    return {
+      status: isOk,
+      message,
+    }
+  }
+  log.error('@kth/monitor - custom system missing property "isOk"', system)
 }
 
 const sleep = async (delay: number) =>

--- a/src/subSystems.ts
+++ b/src/subSystems.ts
@@ -140,7 +140,7 @@ const checkCustomSystem = (system: MonitoredSystem): SystemCheckResult | undefin
     }
     const { isOk, message } = system.customCheck
 
-    if (isOk != undefined && typeof isOk == 'boolean') {
+    if (typeof isOk == 'boolean') {
       return {
         status: isOk,
         message,

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,11 +4,15 @@ export interface SystemCheckResult {
   message?: string
 }
 
+export interface CustomCheckParameters {
+  isOk: boolean
+  message?: string
+}
+
 export type MonitoredSystem = {
   key: string
   name?: string
-  isOk?: boolean
-  message?: string
+  customCheck?: CustomCheckParameters
   required?: boolean
   ignored?: boolean
   db?: any

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,9 @@ export interface SystemCheckResult {
 
 export type MonitoredSystem = {
   key: string
+  name?: string
+  isOk?: boolean
+  message?: string
   required?: boolean
   ignored?: boolean
   db?: any


### PR DESCRIPTION
This PR reintroduces custom systems in a different form than they existed before.

Example configuration for a custom system, to be passed to `monitorRequest`:
```typescript
{
        key: 'custom', // this is crucial for the system to be recognized as custom system
        name: 'someCustomName', // this is a "free text field" 
        isOk: customService.getIsRunning(), // boolean
        message: customService.getMessage(), // string
},
```

* custom system checks are executed if `probe=readyness` or `probe=full`. 
* a new property `name` is introduced, which takes precedence over `key` when requesting a plain response. JSON responses will contain both key and name.
* if something else than a boolean is passed as `isOk`, the system will log an error message and the status will be `UNKNOWN`

Note that I did not touch the README file, because I was unsure how you want this communicated in case it gets merged.