### PR TITLE
Feat/custom external checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.3.0] - 2024-04-10
+
+### Added
+
+- Extend `Custom` systems with support for async function call
+
 ## [4.2.0] - 2023-09-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -126,12 +126,25 @@ Checked on _readyness_ probes
 **Custom**  
 Checked on _readyness_ probes
 
+**_With boolean_**
+
 ```typescript
 {
   key: 'custom',
   customCheck: {
     isOk: boolean,
-    message: string,  // optional message
+    message: string, // optional message
+  }
+}
+```
+
+**_With async function_**
+
+```typescript
+{
+  key: 'custom',
+  customCheck: {
+    lookupFn: // async function returning a boolean
   }
 }
 ```

--- a/src/subSystems.test.ts
+++ b/src/subSystems.test.ts
@@ -49,74 +49,156 @@ describe('select systems to include', () => {
 
 describe('check systems', () => {
   describe('custom systems', () => {
-    const successfulSystem: MonitoredSystem = {
-      key: 'custom',
-      name: 'customSystem',
-      customCheck: {
-        isOk: true,
-        message: 'Some custom message',
-      },
-    }
-    const unsuccessfulSystem: MonitoredSystem = {
-      key: 'custom',
-      name: 'unsuccessfulSystem',
-      customCheck: {
-        isOk: false,
-        message: 'Some error from custom subSystem',
-      },
-    }
-    const invalidCustomSystem: MonitoredSystem = {
-      key: 'custom',
-      name: 'invalidCustomSystem',
-      customCheck: {
-        // @ts-ignore
-        isOk: 200,
-      },
-    }
+    const customSystem = { key: 'custom', name: 'customSystem' } as MonitoredSystem
 
-    const customSystemMissingCustomCheck: MonitoredSystem = {
-      key: 'custom',
-      name: 'customSystemMissingCustomCheck',
-    }
+    it('when "customCheck" exists, creates a successful result when "isOk" is true', async () => {
+      const okSystem = {
+        ...customSystem,
+        customCheck: {
+          isOk: true,
+          message: 'Some custom message',
+        },
+      }
 
-    it('creates a successful result when "isOk" is true', async () => {
-      const checkedSystems = await checkSystems([successfulSystem])
+      const checkedSystems = await checkSystems([okSystem])
 
       expect(checkedSystems[0].name).toEqual('customSystem')
       expect(checkedSystems[0].result?.status).toEqual(true)
       expect(checkedSystems[0].result?.message).toEqual('Some custom message')
     })
 
-    it('creates an unsuccessful result when "isOk" is false', async () => {
-      const checkedSystems = await checkSystems([unsuccessfulSystem])
+    it('when "customCheck" exists, creates an unsuccessful result when "isOk" is false', async () => {
+      const notOkSystem: MonitoredSystem = {
+        ...customSystem,
+        customCheck: {
+          isOk: false,
+          message: 'Some error from custom subSystem',
+        },
+      }
+      const checkedSystems = await checkSystems([notOkSystem])
 
-      expect(checkedSystems[0].name).toEqual('unsuccessfulSystem')
+      expect(checkedSystems[0].name).toEqual('customSystem')
       expect(checkedSystems[0].result?.status).toEqual(false)
       expect(checkedSystems[0].result?.message).toEqual('Some error from custom subSystem')
     })
 
-    it('creates an unsuccessful result if property customCheck is missing', async () => {
-      const checkedSystems = await checkSystems([customSystemMissingCustomCheck])
-      expect(checkedSystems[0].name).toEqual('customSystemMissingCustomCheck')
-      expect(checkedSystems[0].result?.status).toEqual(false)
-      expect(checkedSystems[0].result?.message).toContain(
-        'invalid configuration: custom system missing required property "customCheck"'
-      )
-    })
+    it('when "customCheck" exists, creates an unsuccessful result if property isOk is missing', async () => {
+      const invalidSystem: MonitoredSystem = {
+        ...customSystem,
+        // @ts-ignore   (needed since the required property isOk is missing)
+        customCheck: {},
+      }
+      const checkedSystems = await checkSystems([invalidSystem])
 
-    it('creates an unsuccessful result if property customCheck is missing', async () => {
-      const checkedSystems = await checkSystems([invalidCustomSystem])
-      expect(checkedSystems[0].name).toEqual('invalidCustomSystem')
+      expect(checkedSystems[0].name).toEqual('customSystem')
       expect(checkedSystems[0].result?.status).toEqual(false)
       expect(checkedSystems[0].result?.message).toContain(
         'invalid configuration: custom system missing required property "isOk"'
       )
     })
 
-    it('logs a warning when a custom system does not contain a boolean property "isOk"', async () => {
-      await checkSystems([invalidCustomSystem])
+    it('when "customCheck" exists, creates an unsuccessful result if property isOk is not a boolean', async () => {
+      const invalidSystem: MonitoredSystem = {
+        ...customSystem,
+        // @ts-ignore   (needed since we pass a string where a boolean is expected)
+        customCheck: { isOk: 'notBoolean' },
+      }
+      const checkedSystems = await checkSystems([invalidSystem])
+      expect(checkedSystems[0].name).toEqual('customSystem')
+      expect(checkedSystems[0].result?.status).toEqual(false)
+      expect(checkedSystems[0].result?.message).toContain(
+        'invalid configuration: custom system missing required property "isOk"'
+      )
+    })
 
-      expect(log.warn).toHaveBeenCalled()
+    it('when "customLookup" exists, creates a successful result when "lookupFn" resolves to true', async () => {
+      const okSystem = {
+        ...customSystem,
+        customLookup: {
+          lookupFn: async () => true,
+        },
+      }
+
+      const checkedSystems = await checkSystems([okSystem])
+
+      expect(checkedSystems[0].name).toEqual('customSystem')
+      expect(checkedSystems[0].result?.status).toEqual(true)
+    })
+    it('when "customLookup" exists, creates a unsuccessful result when "lookupFn" resolves to false', async () => {
+      const notOkSystem = {
+        ...customSystem,
+        customLookup: {
+          lookupFn: async () => false,
+        },
+      }
+
+      const checkedSystems = await checkSystems([notOkSystem])
+
+      expect(checkedSystems[0].name).toEqual('customSystem')
+      expect(checkedSystems[0].result?.status).toEqual(false)
+    })
+    it('when "customLookup" exists, creates a unsuccessful result when "lookupFn" rejects', async () => {
+      const notOkSystem = {
+        ...customSystem,
+        customLookup: {
+          lookupFn: async () => {
+            throw new Error('The lookup failed')
+          },
+        },
+      }
+
+      const checkedSystems = await checkSystems([notOkSystem])
+
+      expect(checkedSystems[0].name).toEqual('customSystem')
+      expect(checkedSystems[0].result?.status).toEqual(false)
+      expect(checkedSystems[0].result?.message).toEqual('Error: The lookup failed')
+    })
+    it('when "customLookup" exists, creates a unsuccessful result when "lookupFn" resolves to other than boolean', async () => {
+      const notOkSystem = {
+        ...customSystem,
+        customLookup: {
+          lookupFn: async () => {
+            return 'notBoolean'
+          },
+        },
+      }
+
+      // @ts-ignore   (needed since we return a string where a boolean is expected)
+      const checkedSystems = await checkSystems([notOkSystem])
+
+      expect(checkedSystems[0].name).toEqual('customSystem')
+      expect(checkedSystems[0].result?.status).toEqual(false)
+      expect(checkedSystems[0].result?.message).toEqual('Error: invalid configuration')
+    })
+    it('when both "customCheck" and "customLookup" is missing, creates a unsuccessful result', async () => {
+      const notOkSystem = {
+        ...customSystem,
+      }
+
+      const checkedSystems = await checkSystems([notOkSystem])
+
+      expect(checkedSystems[0].name).toEqual('customSystem')
+      expect(checkedSystems[0].result?.status).toEqual(false)
+      expect(checkedSystems[0].result?.message).toEqual(
+        'Error: invalid configuration: custom system missing required property "customCheck" or "customLookup"'
+      )
+    })
+    it('when both "customCheck" and "customLookup" exists, use result from "customCheck"', async () => {
+      const okSystem = {
+        ...customSystem,
+        customLookup: {
+          lookupFn: jest.fn().mockResolvedValue(false),
+        },
+        customCheck: {
+          isOk: true,
+        },
+      }
+
+      const checkedSystems = await checkSystems([okSystem])
+
+      expect(checkedSystems[0].name).toEqual('customSystem')
+      expect(checkedSystems[0].result?.status).toEqual(true)
+      expect(okSystem.customLookup.lookupFn).not.toHaveBeenCalled()
     })
   })
 

--- a/src/subSystems.test.ts
+++ b/src/subSystems.test.ts
@@ -50,126 +50,6 @@ describe('select systems to include', () => {
 describe('check systems', () => {
   describe('custom systems', () => {
     const customSystem = { key: 'custom', name: 'customSystem' } as MonitoredSystem
-
-    it('when "customCheck" exists, creates a successful result when "isOk" is true', async () => {
-      const okSystem = {
-        ...customSystem,
-        customCheck: {
-          isOk: true,
-          message: 'Some custom message',
-        },
-      }
-
-      const checkedSystems = await checkSystems([okSystem])
-
-      expect(checkedSystems[0].name).toEqual('customSystem')
-      expect(checkedSystems[0].result?.status).toEqual(true)
-      expect(checkedSystems[0].result?.message).toEqual('Some custom message')
-    })
-
-    it('when "customCheck" exists, creates an unsuccessful result when "isOk" is false', async () => {
-      const notOkSystem: MonitoredSystem = {
-        ...customSystem,
-        customCheck: {
-          isOk: false,
-          message: 'Some error from custom subSystem',
-        },
-      }
-      const checkedSystems = await checkSystems([notOkSystem])
-
-      expect(checkedSystems[0].name).toEqual('customSystem')
-      expect(checkedSystems[0].result?.status).toEqual(false)
-      expect(checkedSystems[0].result?.message).toEqual('Some error from custom subSystem')
-    })
-
-    it('when "customCheck" exists, creates an unsuccessful result if property isOk is missing', async () => {
-      const invalidSystem: MonitoredSystem = {
-        ...customSystem,
-        // @ts-ignore   (needed since the required property isOk is missing)
-        customCheck: {},
-      }
-      const checkedSystems = await checkSystems([invalidSystem])
-
-      expect(checkedSystems[0].name).toEqual('customSystem')
-      expect(checkedSystems[0].result?.status).toEqual(false)
-      expect(checkedSystems[0].result?.message).toContain(
-        'invalid configuration: custom system missing required property "isOk"'
-      )
-    })
-
-    it('when "customCheck" exists, creates an unsuccessful result if property isOk is not a boolean', async () => {
-      const invalidSystem: MonitoredSystem = {
-        ...customSystem,
-        // @ts-ignore   (needed since we pass a string where a boolean is expected)
-        customCheck: { isOk: 'notBoolean' },
-      }
-      const checkedSystems = await checkSystems([invalidSystem])
-      expect(checkedSystems[0].name).toEqual('customSystem')
-      expect(checkedSystems[0].result?.status).toEqual(false)
-      expect(checkedSystems[0].result?.message).toContain(
-        'invalid configuration: custom system missing required property "isOk"'
-      )
-    })
-
-    it('when "customLookup" exists, creates a successful result when "lookupFn" resolves to true', async () => {
-      const okSystem = {
-        ...customSystem,
-        customLookup: {
-          lookupFn: async () => true,
-        },
-      }
-
-      const checkedSystems = await checkSystems([okSystem])
-
-      expect(checkedSystems[0].name).toEqual('customSystem')
-      expect(checkedSystems[0].result?.status).toEqual(true)
-    })
-    it('when "customLookup" exists, creates a unsuccessful result when "lookupFn" resolves to false', async () => {
-      const notOkSystem = {
-        ...customSystem,
-        customLookup: {
-          lookupFn: async () => false,
-        },
-      }
-
-      const checkedSystems = await checkSystems([notOkSystem])
-
-      expect(checkedSystems[0].name).toEqual('customSystem')
-      expect(checkedSystems[0].result?.status).toEqual(false)
-    })
-    it('when "customLookup" exists, creates a unsuccessful result when "lookupFn" rejects', async () => {
-      const notOkSystem = {
-        ...customSystem,
-        customLookup: {
-          lookupFn: async () => {
-            throw new Error('The lookup failed')
-          },
-        },
-      }
-
-      const checkedSystems = await checkSystems([notOkSystem])
-
-      expect(checkedSystems[0].name).toEqual('customSystem')
-      expect(checkedSystems[0].result?.status).toEqual(false)
-      expect(checkedSystems[0].result?.message).toEqual('Error: The lookup failed')
-    })
-    it('when "customLookup" exists, creates a unsuccessful result when "lookupFn" resolves to other than boolean', async () => {
-      const notOkSystem = {
-        ...customSystem,
-        customLookup: {
-          lookupFn: async () => {
-            return 'notBoolean'
-          },
-        },
-      }
-
-      // @ts-ignore   (needed since we return a string where a boolean is expected)
-      const checkedSystems = await checkSystems([notOkSystem])
-
-      expect(checkedSystems[0].name).toEqual('customSystem')
-      expect(checkedSystems[0].result?.status).toEqual(false)
-      expect(checkedSystems[0].result?.message).toEqual('Error: invalid configuration')
-    })
     it('when both "customCheck" and "customLookup" is missing, creates a unsuccessful result', async () => {
       const notOkSystem = {
         ...customSystem,
@@ -199,6 +79,128 @@ describe('check systems', () => {
       expect(checkedSystems[0].name).toEqual('customSystem')
       expect(checkedSystems[0].result?.status).toEqual(true)
       expect(okSystem.customLookup.lookupFn).not.toHaveBeenCalled()
+    })
+    describe('when "customCheck" exists', () => {
+      it('creates a successful result when "isOk" is true', async () => {
+        const okSystem = {
+          ...customSystem,
+          customCheck: {
+            isOk: true,
+            message: 'Some custom message',
+          },
+        }
+
+        const checkedSystems = await checkSystems([okSystem])
+
+        expect(checkedSystems[0].name).toEqual('customSystem')
+        expect(checkedSystems[0].result?.status).toEqual(true)
+        expect(checkedSystems[0].result?.message).toEqual('Some custom message')
+      })
+
+      it('creates an unsuccessful result when "isOk" is false', async () => {
+        const notOkSystem: MonitoredSystem = {
+          ...customSystem,
+          customCheck: {
+            isOk: false,
+            message: 'Some error from custom subSystem',
+          },
+        }
+        const checkedSystems = await checkSystems([notOkSystem])
+
+        expect(checkedSystems[0].name).toEqual('customSystem')
+        expect(checkedSystems[0].result?.status).toEqual(false)
+        expect(checkedSystems[0].result?.message).toEqual('Some error from custom subSystem')
+      })
+
+      it('creates an unsuccessful result if property isOk is missing', async () => {
+        const invalidSystem: MonitoredSystem = {
+          ...customSystem,
+          // @ts-ignore   (needed since the required property isOk is missing)
+          customCheck: {},
+        }
+        const checkedSystems = await checkSystems([invalidSystem])
+
+        expect(checkedSystems[0].name).toEqual('customSystem')
+        expect(checkedSystems[0].result?.status).toEqual(false)
+        expect(checkedSystems[0].result?.message).toContain(
+          'invalid configuration: custom system missing required property "isOk"'
+        )
+      })
+
+      it('creates an unsuccessful result if property isOk is not a boolean', async () => {
+        const invalidSystem: MonitoredSystem = {
+          ...customSystem,
+          // @ts-ignore   (needed since we pass a string where a boolean is expected)
+          customCheck: { isOk: 'notBoolean' },
+        }
+        const checkedSystems = await checkSystems([invalidSystem])
+        expect(checkedSystems[0].name).toEqual('customSystem')
+        expect(checkedSystems[0].result?.status).toEqual(false)
+        expect(checkedSystems[0].result?.message).toContain(
+          'invalid configuration: custom system missing required property "isOk"'
+        )
+      })
+    })
+    describe('when "customLookup" exist', () => {
+      it('creates a successful result when "lookupFn" resolves to true', async () => {
+        const okSystem = {
+          ...customSystem,
+          customLookup: {
+            lookupFn: async () => true,
+          },
+        }
+
+        const checkedSystems = await checkSystems([okSystem])
+
+        expect(checkedSystems[0].name).toEqual('customSystem')
+        expect(checkedSystems[0].result?.status).toEqual(true)
+      })
+      it('creates a unsuccessful result when "lookupFn" resolves to false', async () => {
+        const notOkSystem = {
+          ...customSystem,
+          customLookup: {
+            lookupFn: async () => false,
+          },
+        }
+
+        const checkedSystems = await checkSystems([notOkSystem])
+
+        expect(checkedSystems[0].name).toEqual('customSystem')
+        expect(checkedSystems[0].result?.status).toEqual(false)
+      })
+      it('creates a unsuccessful result when "lookupFn" rejects', async () => {
+        const notOkSystem = {
+          ...customSystem,
+          customLookup: {
+            lookupFn: async () => {
+              throw new Error('The lookup failed')
+            },
+          },
+        }
+
+        const checkedSystems = await checkSystems([notOkSystem])
+
+        expect(checkedSystems[0].name).toEqual('customSystem')
+        expect(checkedSystems[0].result?.status).toEqual(false)
+        expect(checkedSystems[0].result?.message).toEqual('Error: The lookup failed')
+      })
+      it('creates a unsuccessful result when "lookupFn" resolves to other than boolean', async () => {
+        const notOkSystem = {
+          ...customSystem,
+          customLookup: {
+            lookupFn: async () => {
+              return 'notBoolean'
+            },
+          },
+        }
+
+        // @ts-ignore   (needed since we return a string where a boolean is expected)
+        const checkedSystems = await checkSystems([notOkSystem])
+
+        expect(checkedSystems[0].name).toEqual('customSystem')
+        expect(checkedSystems[0].result?.status).toEqual(false)
+        expect(checkedSystems[0].result?.message).toEqual('Error: invalid configuration')
+      })
     })
   })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,11 +8,15 @@ export interface CustomCheckParameters {
   isOk: boolean
   message?: string
 }
+export interface CustomLookupParameters {
+  lookupFn: () => Promise<boolean>
+}
 
 export type MonitoredSystem = {
   key: string
   name?: string
   customCheck?: CustomCheckParameters
+  customLookup?: CustomLookupParameters
   required?: boolean
   ignored?: boolean
   db?: any


### PR DESCRIPTION
A new way to check external systems, by passing an async function rather than a boolean property.



This could almost be achieved by just evaluating a new boolean result on every call to "_monitor", but that would check the external system on every call, not just when `probe=full` is passed.
That could lead to cases where issues in external systems prevents the app from being deployed properly.

This new function will only be evaluated when needed.